### PR TITLE
GSC Image for Nitro v3.5.2

### DIFF
--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.3.2-celestia-5ed9cd8
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:9v3.5.2-fda7509
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 


### PR DESCRIPTION
This pull request includes an update to the Docker image version in the `config/Dockerfile.sgx-poster` file. The change updates the base image used for the Docker container.

* [`config/Dockerfile.sgx-poster`](diffhunk://#diff-5c5ba81555a08af7b4b4e375edcfffd13309c2ceead309ba335da7648ede9a40L1-R1): Updated the base image from `ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.3.2-celestia-5ed9cd8` to `ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:9v3.5.2-fda7509`.