### PR TITLE
Flint Testnet

### DIFF
--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.3.2-celestia-5ed9cd8
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-6d6746e
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 


### PR DESCRIPTION
**Flint Testnet**
* **Dockerfile update**:
  - Updated the base image from `ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.3.2-celestia-5ed9cd8` to `ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-6d6746e`.