### PR TITLE
Flint Mainnet

### DIFF
--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.3.2-celestia-5ed9cd8
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-6d6746e
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 

--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-6d6746e
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-celestia-2e37e3c
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 

--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:release-with-multi-client-v3.5.2-6d6746e
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-6d6746e
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 

--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-celestia-2e37e3c
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:celestia-integration
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 

--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-6d6746e
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:release-with-multi-client-v3.5.2-6d6746e
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 

--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:celestia-integration
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:v3.5.2-celestia-2e37e3c
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 


### PR DESCRIPTION
GSC Image for nitro v3.5.2 without multi client and using v0.
