### PR TITLE
Update image to add debug logs for batch overflows

### DIFF
--- a/config/Dockerfile.sgx-poster
+++ b/config/Dockerfile.sgx-poster
@@ -1,4 +1,4 @@
-FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:release-v3.5.2-without-multi-client-v0
+FROM ghcr.io/espressosystems/nitro-espresso-integration/nitro-node:release-v3.5.2-overflow-debug
 
 RUN curl -L -o kzg10-aztec20-srs-1048584.bin https://github.com/EspressoSystems/ark-srs/releases/download/v0.2.0/kzg10-aztec20-srs-1048584.bin
 


### PR DESCRIPTION
## Description of the changes: 

Updates the flint mainnet image to contain debug logs for various situations in which adding a message to the batch would cause an overflow.

## Related [PR](https://github.com/EspressoSystems/nitro-espresso-integration/pull/588)


