### PR TITLE
Add sigterm injection for clean shutdowns

### DIFF
--- a/nitro-espresso.manifest
+++ b/nitro-espresso.manifest
@@ -2,6 +2,7 @@ sys.enable_extra_runtime_domain_names_conf = true
 sgx.edmm_enable = true
 sgx.remote_attestation = "dcap"
 sgx.use_exinfo = true
+sys.enable_sigterm_injection = true
 sys.experimental__enable_flock = true
 fs.mounts = [
     { path = "/home/user/.arbitrum/", uri = "file:/home/user/.arbitrum"},


### PR DESCRIPTION
Without this every shutdown of nitro is immedate and unclean. This can cause data corruption and needs to be avoided.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

